### PR TITLE
Allow for searching by tag, description

### DIFF
--- a/src/EmojiCompletionProvider.ts
+++ b/src/EmojiCompletionProvider.ts
@@ -57,7 +57,7 @@ export default class EmojiCompletionProvider implements vscode.CompletionItemPro
                 label: `:${x.name}: ${x.emoji}`,
                 description: x.tags.join(', '),
             }, kind);
-            item.filterText = `:${x.tags.join(' ')} ${x.name} ${x.description} ${x.category}:`;
+            item.filterText = `:${x.name} ${x.tags.join(' ')} ${x.description} ${x.category}:`;
             item.documentation = new vscode.MarkdownString([
                 `# ${x.emoji}`,
                 `_${x.category}: ${x.tags.concat(x.description).join(', ')}_`,
@@ -82,7 +82,7 @@ export default class EmojiCompletionProvider implements vscode.CompletionItemPro
                 label: `::${x.name} ${x.emoji}`,
                 description: x.tags.join(',  ')
             }, kind);
-            item.filterText = `::${x.tags.join(' ')} ${x.name} ${x.description} ${x.category}`;
+            item.filterText = `::${x.name} ${x.tags.join(' ')} ${x.description} ${x.category}`;
             item.documentation = new vscode.MarkdownString([
                 `# ${x.emoji}`,
                 `_${x.category}: ${x.tags.concat(x.description).join(', ')}_`,

--- a/src/EmojiCompletionProvider.ts
+++ b/src/EmojiCompletionProvider.ts
@@ -40,8 +40,7 @@ export default class EmojiCompletionProvider implements vscode.CompletionItemPro
             return this.getMarkupEmojiCompletions(document, replacementSpan);
         }
 
-        return this.getUnicodeEmojiCompletions(document, replacementSpan)
-            .concat(this.getMarkupEmojiCompletions(document, replacementSpan));
+        return this.getUnicodeEmojiCompletions(document, replacementSpan);
     }
 
     private getUnicodeEmojiCompletions(
@@ -54,9 +53,15 @@ export default class EmojiCompletionProvider implements vscode.CompletionItemPro
 
         const kind = vscode.CompletionItemKind.Text;
         return this.emojiProvider.emojis.map((x) => {
-            const item = new vscode.CompletionItem(`:${x.name}: ${x.emoji}`, kind);
-            item.filterText = `:${x.name}:`;
-            item.documentation = new vscode.MarkdownString(`# ${x.emoji}`);
+            const item = new vscode.CompletionItem({
+                label: `:${x.name}: ${x.emoji}`,
+                description: x.tags.join(', '),
+            }, kind);
+            item.filterText = `:${x.tags.join(' ')} ${x.name} ${x.description} ${x.category}:`;
+            item.documentation = new vscode.MarkdownString([
+                `# ${x.emoji}`,
+                `_${x.category}: ${x.tags.concat(x.description).join(', ')}_`,
+            ].join('\n'));
             item.insertText = x.emoji;
             item.range = replacementSpan;
             return item;
@@ -73,9 +78,15 @@ export default class EmojiCompletionProvider implements vscode.CompletionItemPro
 
         const kind = vscode.CompletionItemKind.Text;
         return this.emojiProvider.emojis.map((x) => {
-            const item = new vscode.CompletionItem(`::${x.name} ${x.emoji}`, kind);
-            item.filterText = `::${x.name}`;
-            item.documentation = new vscode.MarkdownString(`# ${x.emoji}`);
+            const item = new vscode.CompletionItem({
+                label: `::${x.name} ${x.emoji}`,
+                description: x.tags.join(',  ')
+            }, kind);
+            item.filterText = `::${x.tags.join(' ')} ${x.name} ${x.description} ${x.category}`;
+            item.documentation = new vscode.MarkdownString([
+                `# ${x.emoji}`,
+                `_${x.category}: ${x.tags.concat(x.description).join(', ')}_`,
+            ].join('\n'));
             item.insertText = `:${x.name}:`;
             item.range = replacementSpan;
             return item;

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -3,6 +3,9 @@ import { gemoji } from 'gemoji';
 export interface Emoji {
     readonly name: string;
     readonly emoji: string;
+    readonly tags: string[];
+    readonly description: string;
+    readonly category: string;
 }
 
 export class EmojiProvider {
@@ -26,7 +29,13 @@ export class EmojiProvider {
             for (const g of gemoji) {
                 for (const name of g.names) {
                     if (!this._emojiMap.has(name)) {
-                        this._emojiMap.set(name, { name, emoji: g.emoji });
+                        this._emojiMap.set(name, { 
+                            name, 
+                            emoji: g.emoji,
+                            tags: g.tags,
+                            description: g.description,
+                            category: g.category
+                         });
                     }
                 }
             }


### PR DESCRIPTION
Allow searching by tag or description, in addition to the actual emoji name.

For example, we can search by the `:rich:` tag to get 🤑 , by the `:flirt:` tag to get either 😉  or 😘 , or the `:downcast` description to get 😓 

To support this, our `emojiMap` needs to support multiple matching emojis for each lookup term. I also updated the completion provider to show the search term to the right of the actual emoji name.

---

BTW, I love this extension thanks @mattbierner for sharing all your hard work on this! I teach at a programming bootcamp, and it adds some needed fun to remote lectures 😄 

**Demo**
![2021-10-07 10 29 31](https://user-images.githubusercontent.com/1153371/136417869-7d467aa2-ef69-433d-8262-bc09171bcb55.gif)

**Gemoji Data**
For the demo's emojis
```json

  {
    "emoji": "🤑",
    "names": [
      "money_mouth_face"
    ],
    "tags": [
      "rich"
    ],
    "description": "money-mouth face",
    "category": "Smileys & Emotion"
  },
  {
    "emoji": "😘",
    "names": [
      "kissing_heart"
    ],
    "tags": [
      "flirt"
    ],
    "description": "face blowing a kiss",
    "category": "Smileys & Emotion"
  },
  {
    "emoji": "😉",
    "names": [
      "wink"
    ],
    "tags": [
      "flirt"
    ],
    "description": "winking face",
    "category": "Smileys & Emotion"
  },
  {
    "emoji": "😓",
    "names": [
      "sweat"
    ],
    "tags": [],
    "description": "downcast face with sweat",
    "category": "Smileys & Emotion"
  },
```
