### PR TITLE
Feature: Add setting to implicitly enable emoji for all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Inspired by the [Atom autocomplete+ emojis suggestions plugin][atom].
 
 - `emojisense.emojiDecoratorsEnabled`: Show emoji decorators inline for `:smile_cat:` markup in a file? Enabled by default in markdown.
 
+- `emojisense.enableForAllLanguages`: Enable implicitly for all languages.
+
 ## Per Language Configuration
 
 *Emojisense* is enabled by default in markdown, git commits, and plaintext files. You can enable it in other languages using `"emojisense.languages"`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emojisense",
   "displayName": ":emojisense:",
   "description": "Adds suggestions and autocomplete for emoji",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "publisher": "bierner",
   "icon": "media/icon.png",
   "license": "MIT",
@@ -122,6 +122,11 @@
           "type": "boolean",
           "description": "Enables or disables emoji decorators for emoji markup.",
           "default": true
+        },
+        "emojisense.enableForAllLanguages": {
+          "type": "boolean",
+          "markdownDescription": "Enable emoji for all languages by default",
+          "default": false
         },
         "emojisense.languages": {
           "type": "object",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,10 +19,12 @@ function registerProviders(
     return vscode.Disposable.from(...disposables);
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
     const emoji = new EmojiProvider();
     const config = new Configuration();
     const provider = new EmojiCompletionProvider(emoji, config);
+
+    await config.updateConfiguration();
 
     let providerSub = registerProviders(provider, config);
 
@@ -34,8 +36,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('emojisense.quickEmojitextTerminal', emojiPicker('name', 'terminal')),
     );
 
-    vscode.workspace.onDidChangeConfiguration(() => {
-        config.updateConfiguration();
+    vscode.workspace.onDidChangeConfiguration(async () => {
+        await config.updateConfiguration();
         providerSub.dispose();
         providerSub = registerProviders(provider, config);
     }, null, context.subscriptions);


### PR DESCRIPTION
### Description

- Add new flag `enableForAllLanguages` to enable emoji implicitly on all languages
- Default configuration is `false`
- Will not impact old configurations

### Issue

https://github.com/mattbierner/vscode-emojisense/issues/10

### Checks

- [x] Manually tested
- [x] Passes build
